### PR TITLE
Add missing '#include <vector>'

### DIFF
--- a/cySampleElim.h
+++ b/cySampleElim.h
@@ -63,6 +63,7 @@
 #include "cyCore.h"
 #include "cyHeap.h"
 #include "cyPointCloud.h"
+#include <vector>
 
 //-------------------------------------------------------------------------------
 namespace cy {


### PR DESCRIPTION
Hi,

Thanks for the nice library!

When using `cySampleElim.h`, MSVC 16.9.5 complains about using std::vector without including \<vector\>. So I try to fix it in this pr.