### PR TITLE
add ARM64 support for M-series chip (Apple).

### DIFF
--- a/cyCore.h
+++ b/cyCore.h
@@ -52,8 +52,12 @@
 #include <type_traits>
 #include <limits>
 
-#if !defined(CY_NO_INTRIN_H) && !defined(CY_NO_EMMINTRIN_H) && !defined(CY_NO_IMMINTRIN_H)
-# include <immintrin.h>
+#if (!defined(CY_NO_INTRIN_H) && !defined(CY_NO_EMMINTRIN_H) && \
+     !defined(CY_NO_IMMINTRIN_H)) &&                            \
+    !(defined(__aarch64__) || defined(__arm__))
+  #include <immintrin.h>
+#elif defined(__aarch64__) || defined(__arm__)
+  #include <arm_neon.h>   // Apple Silicon/ARM
 #endif
 
 //-------------------------------------------------------------------------------


### PR DESCRIPTION
Currently, we cannot compile this library in the new Apple arm64 platform with SIMD, using `immintrin.h` header file.

We need to use `arm_neon.h` for this functionality.

I also reported the issue here:
https://github.com/cemyuksel/cyCodeBase/issues/18#issuecomment-2848584895